### PR TITLE
DROP chore: Trigger CI with new changes and not with empty commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - 'v*'
+      - "v*"
 
 name: Release policy
 
 jobs:
-
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.2
+    uses: viccuad/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.3-viccuad
 
   release:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,4 +3,4 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.2
+    uses: viccuad/github-actions/.github/workflows/reusable-test-policy-rust.yml@v3.3.3-viccuad

--- a/e2e.bats
+++ b/e2e.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+echo "This is to trigger CI!"
+
 @test "Accept a valid signature" {
   run kwctl run  --request-path test_data/pod_creation_signed.json --settings-path test_data/settings-mutation-enabled.yaml annotated-policy.wasm
 


### PR DESCRIPTION
Testing if e2e tests are on CI.